### PR TITLE
fix(ci): resolve workspace typecheck via TypeScript Project References (closes #12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
     "packages/middleware"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
-    "typecheck": "npm run typecheck --workspaces",
+    "build": "tsc -b",
+    "typecheck": "tsc -b",
+    "pretest": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rm -rf packages/*/dist"
+    "clean": "tsc -b --clean && rm -rf packages/*/dist packages/*/*.tsbuildinfo"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/anthropic/package.json
+++ b/packages/anthropic/package.json
@@ -13,8 +13,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc -b",
+    "typecheck": "tsc -b"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.30.0"

--- a/packages/anthropic/tsconfig.json
+++ b/packages/anthropic/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,8 +12,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc -b",
+    "typecheck": "tsc -b"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src"]
 }

--- a/packages/gemini/package.json
+++ b/packages/gemini/package.json
@@ -13,8 +13,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc -b",
+    "typecheck": "tsc -b"
   },
   "peerDependencies": {
     "@google/generative-ai": ">=0.15.0"

--- a/packages/gemini/tsconfig.json
+++ b/packages/gemini/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -21,8 +21,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc -b",
+    "typecheck": "tsc -b"
   },
   "peerDependencies": {
     "express": ">=4.0.0",

--- a/packages/middleware/tsconfig.json
+++ b/packages/middleware/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -13,8 +13,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "build": "tsc -b",
+    "typecheck": "tsc -b"
   },
   "peerDependencies": {
     "openai": ">=4.0.0"

--- a/packages/openai/tsconfig.json
+++ b/packages/openai/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,6 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    "outDir": "dist",
-    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -16,7 +14,15 @@
     "sourceMap": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "disableSourceOfProjectReferenceRedirect": true
   },
-  "exclude": ["node_modules", "dist", "tests"]
+  "files": [],
+  "references": [
+    { "path": "packages/core" },
+    { "path": "packages/openai" },
+    { "path": "packages/anthropic" },
+    { "path": "packages/gemini" },
+    { "path": "packages/middleware" }
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes the broken CI typecheck job that has been blocking all PRs (including 6 Dependabot PRs) since at least 2026-05-04. Closes #12.

## Root cause

`npm run typecheck --workspaces` ran tsc on consumer packages (`openai`, `anthropic`, `gemini`, `middleware`) before `ai-shield-core` had been built, so `import "ai-shield-core"` could not be resolved.

```
src/wrapper.ts(1,70): error TS2307: Cannot find module 'ai-shield-core' or its corresponding type declarations.
```

Locally this was masked because the workspace symlink pointed at a previously-built `dist/`. Cold CI runs got nothing.

A follow-on TS7006 in `middleware/src/shared.ts:58` ("Parameter 'v' implicitly any") was a direct consequence — `ScanResult` resolved to `any`, so `.violations.map((v) => …)` had no type for `v`.

## Fix

Switch the monorepo to **TypeScript Project References + composite mode**, with `tsc -b` as the root build/typecheck driver. This was option 1 from the issue ("preferred").

### Changes

| File | Change |
|------|--------|
| `tsconfig.json` (root) | `files: []` + `references` (5 packages) + `disableSourceOfProjectReferenceRedirect: true`; drop dead `outDir` / `rootDir` |
| `packages/core/tsconfig.json` | + `composite: true` |
| `packages/{openai,anthropic,gemini,middleware}/tsconfig.json` | + `composite: true` + `references: [{ path: "../core" }]` |
| `package.json` (root scripts) | `build` / `typecheck` -> `tsc -b`; `pretest` runs `tsc -b` once; `test` -> `vitest run`; `clean` cleans tsbuildinfo too |
| `packages/*/package.json` scripts | `tsc` / `tsc --noEmit` -> `tsc -b` (composite forbids `--noEmit` standalone) |

`.github/workflows/ci.yml` is **unchanged** — it already calls `npm run typecheck` and `npm test`, which now route through `tsc -b`.

## Verification done locally

- `npm run clean` ok
- `npm run typecheck` ok (no output = success)
- `npm run build` ok (all 5 packages emit `dist/` + `.d.ts`)
- `npm test` -> **353 / 353 passed** (781 ms)
- `cd packages/openai && npm run typecheck` ok (was broken before, now works)

Plus a self-review / code review pass with the `feature-dev:code-reviewer` agent — 1 critical + 3 medium findings, all addressed in this commit:
1. removed double `tsc -b` from `test` (now `pretest` hook)
2. migrated per-package scripts to `tsc -b` (composite forbids `--noEmit`)
3. added `disableSourceOfProjectReferenceRedirect: true` for editor performance
4. dropped dead `outDir` / `rootDir` from root tsconfig

## Test plan

- [x] `npm run typecheck` passes (CI must confirm)
- [x] `npm run build` produces `packages/*/dist/`
- [x] `npm test` 353/353 passes
- [x] Per-package scripts (`cd packages/X && npm run typecheck`) pass
- [ ] CI matrix (Node 20, Node 22) green on this PR

## After merge

- Reopen the 6 Dependabot PRs (or wait for next weekly sweep on Monday)
- Cache `*.tsbuildinfo` in CI for faster incremental runs (separate, not blocking)